### PR TITLE
Fix outdated sequence number for 規則

### DIFF
--- a/data/n4.csv
+++ b/data/n4.csv
@@ -348,7 +348,7 @@
 1222700,"汽車","きしゃ","steam train","waller",
 1225130,"技術","ぎじゅつ","art,technology,skill","waller",
 1222840,"季節","きせつ","season","waller",
-1223020,"規則","きそく","regulations","waller",
+1223021,"規則","きそく","regulations","waller",
 1003430,,"きっと","surely","waller",
 1003430,"屹度","きっと","surely","jmdict","きっと"
 1003430,"急度","きっと","surely","jmdict","きっと"


### PR DESCRIPTION
My script failed to find one of the words by its sequence number in JMdict file and turns out it was modified

You can see it here: https://www.edrdg.org/jmwsgi/srchres.py?s1=1&y1=2&t1=%E8%A6%8F%E5%89%87&src=1&search=Search&svc=jmdict&sid=xxx

Status(S) for 規則 with 1223020 number is Rejected (R) and now it's under 1223021 sequence number