### PR TITLE
Fix definition for n5 word せっけん

### DIFF
--- a/original_data/n5.csv
+++ b/original_data/n5.csv
@@ -325,7 +325,7 @@ jmdict_seq,kana,kanji,waller_definition
 2147990,せ,背,"height, stature"
 1379380,せいと,生徒,Pupil
 1074270,セーター,,"sweater, jumper"
-1382590,せっけん,石鹸,Economy
+1382590,せっけん,,soap
 1472740,せびろ,背広,business suit
 1237680,せまい,狭い,Narrow
 2839962,ゼロ,,Zero


### PR DESCRIPTION
Soap in jmdict https://www.edrdg.org/jmwsgi/entr.py?svc=jmdict&e=2307599
Tanos https://web.archive.org/web/20200217033919/http://www.tanos.co.uk/jlpt/jlpt5/vocab/

I'm not sure if you would like to keep the kanji reading, it's not present on the tanos website and seems quite complicated for n5 list

There's also やる with complicated 遣る kanji reading in the n5 list and several other places that differ compared to the tanos website that I would preferably want to fix. I wrote a simple script for diff detection, I can attach the output if you want to take a look